### PR TITLE
docs: add write-up for mission 0x02 (sophia → angela)

### DIFF
--- a/venus/0x02.md
+++ b/venus/0x02.md
@@ -1,0 +1,69 @@
+# 0x02
+
+This write-up walks through how mission 0x02 was completed, moving from user `sophia` to `angela`.
+
+---
+
+In the home directory, read the `mission.txt`:
+
+```bash
+sophia@venus:~$ cat mission.txt
+################
+# MISSION 0x02 #
+################
+
+## EN ##
+The user angela has saved her password in a file but she does not remember where ... she only remembers that the file was called whereismypazz.txt
+
+## ES ##
+La usuaria angela ha guardado su password en un fichero pero no recuerda donde... solo recuerda que el fichero se llamaba whereismypazz.txt
+```
+
+basically, our objective is to find a file called `whereismypazz.txt`.
+
+Since we don't know where the file is, using `find` command will be really helpful in this case.
+
+```bash
+sophia@venus:~$ find / -type f -name "whereismypazz.txt" 2>/dev/null
+/usr/share/whereismypazz.txt
+```
+
+It starts searching from `/` root directory, specifying the type and the exact name.
+
+`2>/dev/null` is simply redirected standard error output to `/dev/null`. So, the screen stays clear from permission errors.
+
+Just read that file:
+
+```bash
+sophia@venus:~$ cat /usr/share/whereismypazz.txt
+[REDACTED]
+```
+
+Got the password for user `angela`, let's check if it works:
+
+```bash
+sophia@venus:~$ su - angela
+Password:
+angela@venus:~$ whoami ; id
+angela
+uid=1003(angela) gid=1003(angela) groups=1003(angela),1054(www3)
+```
+
+We're now logged in as `angela`, print out the flag:
+
+```bash
+angela@venus:~$ ls -la
+total 108
+drwxr-x--- 2 root   angela  4096 Apr  5  2024 .
+drwxr-xr-x 1 root   root    4096 Apr  5  2024 ..
+-rw-r--r-- 1 angela angela   220 Apr 23  2023 .bash_logout
+-rw-r--r-- 1 angela angela  3526 Apr 23  2023 .bashrc
+-rw-r--r-- 1 angela angela   807 Apr 23  2023 .profile
+-rw-r----- 1 root   angela 73888 Apr  5  2024 findme.txt
+-rw-r----- 1 root   angela    31 Apr  5  2024 flagz.txt
+-rw-r----- 1 root   angela   216 Apr  5  2024 mission.txt
+angela@venus:~$ cat flagz.txt
+[REDACTED]
+```
+
+Objective Secured.


### PR DESCRIPTION
This pull request adds the completed write-up for **Venus mission 0x02**, describing the steps taken to escalate privileges from user `sophia` to `angela`.

---

#### 🧾 Changes Introduced
- Added new file: `venus/0x02.md`
- Documented commands, reasoning, and results for mission 0x02
- Follows the same documentation structure as previous write-ups (0x01)

---

#### 🧩 Linked Issue
Closes #2 

---

#### ✅ Review Checklist
- [x] Verify markdown formatting and code block consistency
- [x] Ensure technical accuracy and readability
- [x] Confirm file naming and path conventions