### PR TITLE
docs: add write-up for mission 0x03 (angela > emma)

### DIFF
--- a/venus/0x03.md
+++ b/venus/0x03.md
@@ -1,0 +1,47 @@
+# 0x03
+
+This write-up walks through how mission 0x03 was completed, moving from user `angela` to `emma`.
+
+---
+
+As usual, read the objective:
+
+```bash
+angela@venus:~$ cat mission.txt
+################
+# MISSION 0x03 #
+################
+
+## EN ##
+The password of the user emma is in line 4069 of the file findme.txt
+
+## ES ##
+La password de la usuaria emma esta en la linea 4069 del fichero findme.txt
+```
+
+In the home directory there is a file named `findme.txt` and the password for user `emma` is in line 4069. To find exactly line 4069 use `sed` command.
+
+```bash
+angela@venus:~$ sed -n "4069p" findme.txt
+[REDACTED]
+```
+
+The `sed` command prints a specific line from a file. `-n` suppresses other output, and `"4069"` tells `sed` to print line 4069 only.
+
+After retrieving the password, switch to `emma` user:
+
+```bash
+angela@venus:~$ su - emma
+Password:
+emma@venus:~$ whoami;id
+emma
+uid=1004(emma) gid=1004(emma) groups=1004(emma)
+```
+
+That confirms the privelege escalation was successful. Print out the flag:
+
+```bash
+emma@venus:~$ cat flagz.txt
+[REDACTED]
+```
+Objective Secured.


### PR DESCRIPTION
### Summary
This PR adds the write-up for mission **0x03** on the `venus` machine, documenting the privilege escalation path from user `angela` to `emma`.

### Details
- Included mission objective (EN & ES)
- Explained the use of `sed` to extract the password from line 4069
- Demonstrated switching users via `su - emma`
- Verified privilege escalation and flag retrieval

### Checklist
- [x] Added write-up content in markdown
- [x] Verified grammar and formatting consistency
- [x] Maintained consistent tone with previous missions (0x01–0x02)

**Mission Status:** ✅ Completed (`angela → emma`)

### Linked Issues
- Closed: #5
