### PR TITLE
docs: add write-up for mission 0x05 (mia > camila)

### DIFF
--- a/venus/0x05.md
+++ b/venus/0x05.md
@@ -1,0 +1,61 @@
+# 0x05
+
+This write-up walks through how mission 0x05 was completed, moving from user `mia` to `camila`.
+
+---
+
+As usual, read the objective for this mission:
+
+```bash
+mia@venus:~$ cat mission.txt
+################
+# MISSION 0x05 #
+################
+
+## EN ##
+It seems that the user camila has left her password inside a folder called hereiam
+
+## ES ##
+Parece que la usuaria camila ha dejado su password dentro de una carpeta llamada hereiam
+```
+
+Because we don't know where the `hereiam` folder is, we locate it using `find`:
+
+```bash
+mia@venus:~$ find / -type d -name "hereiam" 2>/dev/null
+/opt/hereiam
+```
+
+The `find` command here searches from the root `/` for directories (`-type d`) named hereiam (`-name hereiam`), suppressing permission errors by redirecting stderr to `/dev/null`.
+
+Move into that folder and read the password:
+
+```bash
+mia@venus:~$ cd /opt/hereiam/
+mia@venus:/opt/hereiam$ ls -la
+total 12
+drwxr-xr-x 2 root root 4096 Apr  5  2024 .
+drwxr-xr-x 1 root root 4096 Apr  5  2024 ..
+-rw-r--r-- 1 root root   16 Apr  5  2024 .here
+mia@venus:/opt/hereiam$ cat .here
+[REDACTED]
+```
+
+Switch to user `camila` to verify the password works:
+
+```bash
+mia@venus:/opt/hereiam$ su - camila
+Password:
+camila@venus:~$ whoami ; id
+camila
+uid=1006(camila) gid=1006(camila) groups=1006(camila)
+```
+
+Successfully logged in as `camila`. Now,read the flag:
+
+```bash
+camila@venus:~$ cat flagz.txt
+[REDACTED]
+```
+
+Objective Secured.


### PR DESCRIPTION
Issue: #7 

Add write-up for **mission 0x05** on the `venus` machine.

### Description

This PR adds a complete write-up for mission 0x05 (mia > camilla). It includes the mission text (EN/ES), an estimated approach based on the hint in `mission.txt`, the commands and outputs used to locate and read the password (with sensitive data redacted), validation of access (`su`, `whoami`, `id`), and the final flag retrieval step.

### Deliverables / Checklist
- [x] Include mission text (EN/ES)
- [x] Describe estimated approach based on hint
- [x] Commands & output (passwords/flags redacted)
- [x] Validate access (`su` / `whoami` / `id`)
- [x] Show final command to retrieve flag (e.g., `cat flagz.txt`)
- [ ] Find hidden flag (optional) 