### PR TITLE
docs: add write-up for mission 0x07 (luna > eleanor)

### DIFF
--- a/venus/0x07.md
+++ b/venus/0x07.md
@@ -1,0 +1,52 @@
+# 0x07
+
+This write-up walks through how mission 0x07 was completed, moving from user `luna` to `eleanor`.
+
+---
+
+As usual, read the objective first:
+
+```bash
+luna@venus:~$ cat mission.txt 
+################
+# MISSION 0x07 #
+################
+
+## EN ##
+The user eleanor has left her password in a file that occupies 6969 bytes.  
+
+## ES ##
+La usuaria eleanor ha dejado su password en un fichero que ocupa 6969 bytes.
+```
+
+From the mission, the name of the file isn't specified explicitly but the size of the file is. 
+
+So, locate the file using `find` command:
+
+```bash
+luna@venus:~$ find / -type f -size 6969c 2>/dev/null
+/usr/share/moon.txt
+```
+
+Searching from root directory and specified the size file as well as suppressing the standard error. Read that file:
+
+```bash
+luna@venus:~$ cat /usr/share/moon.txt 
+[REDACTED]
+```
+
+switch to user `eleanor` to verify it:
+
+```bash
+eleanor@venus:~$ whoami ; id
+eleanor
+uid=1008(eleanor) gid=1008(eleanor) groups=1008(eleanor)
+```
+
+Go get the flag:
+```bash
+eleanor@venus:~$ cat flagz.txt 
+[REDACTED]
+```
+
+Objective secured.


### PR DESCRIPTION
### Description

Resolves #9 

This PR adds the complete write-up for **Mission 0x07** on the `venus` machine. The solution documents the privilege escalation path from user `luna` to `eleanor`.

### Solution Summary
As per the hint in `mission.txt`, the password for `eleanor` is located in a file that is **6969 bytes** in size.

1. The command `find / -type f -size 6969c 2>/dev/null` was used to search the entire system for this file.
2. The file was found at `/usr/share/moon.txt`.
3. Reading the file revealed the password for `eleanor`.
4. Access was validated using `whoami` and `id`.
5. The user flag for `eleanor` was retrieved from `flagz.txt`.

### Issue Checklist
- [x] Include mission text (EN/ES if present)
- [x] Describe estimated approach based on hint
- [x] Command steps & outputs (passwords redacted)
- [x] Validate access (`su`/`ssh` or equivalent) — show `whoami` and `id`
- [x] Show final command to retrieve flag (e.g., `cat /home/<user>/flag.txt`)
- [ ] Find hidden flag (optional)