### PR TITLE
docs: add write-up for mission 0x08 (eleanor > victoria)

### DIFF
--- a/venus/0x08.md
+++ b/venus/0x08.md
@@ -1,0 +1,57 @@
+# 0x08
+
+This write-up walks through how mission 0x08 was completed, moving from user `eleanor` to `victoria` and secured `victoria`'s flag.
+
+---
+
+As always, read the objective first:
+
+```bash
+eleanor@venus:~$ cat mission.txt 
+################
+# MISSION 0x08 #
+################
+
+## EN ##
+The user victoria has left her password in a file in which the owner is the user violin. 
+
+## ES ##
+La usuaria victoria ha dejado su password en un fichero en el cual el propietario es el usuario violin.
+```
+
+From the desription victoria's password is in a file owned by violin.
+
+Locate that file using `find` command:
+
+```bash
+eleanor@venus:~$ find / -type f -user violin 2>/dev/null
+/usr/local/games/yo
+```
+
+Basically, we are specified the thing we searching for like it's type a file (`-type f`) and it's owner (`-user violin`) from root (`/`) directory as well as suppressing all error output messages (`2>/dev/null`).
+
+Read that file:
+
+```bash
+eleanor@venus:~$ cat /usr/local/games/yo
+[REDACTED]
+```
+
+verify it by switching to `victoria` user:
+
+```bash
+eleanor@venus:~$ su - victoria
+Password: 
+victoria@venus:~$ whoami ; id
+victoria
+uid=1009(victoria) gid=1009(victoria) groups=1009(victoria)
+```
+
+Succesfully logged in as `victoria`, get the flag:
+
+```bash
+victoria@venus:~$ cat flagz.txt 
+[REDACTED]
+```
+
+Objective Secured.


### PR DESCRIPTION
### Description

Resolves #10 

This PR adds the complete write-up for **Mission 0x08** on the `venus` machine. This solution details the privilege escalation path from user `eleanor` to `victoria`.

#### Solution Summary
Based on the hint from `mission.txt`, the password for `victoria` is stored in a file where the owner is the user `violin`.

1.  The command `find / -type f -user violin 2>/dev/null` was executed to search the filesystem for any files owned by `violin`.
2.  The command identified the target file at `/usr/local/games/yo`.
3.  Reading this file (`cat /usr/local/games/yo`) revealed the password for `victoria`.
4.  Access was successfully validated by switching users with `su - victoria` and confirming identity with `whoami ; id`.
5.  The user flag was retrieved by running `cat flagz.txt`.

#### Issue Checklist
- [x] Include mission text (EN/ES if present)
- [x] Describe estimated approach based on hint
- [x] Command steps & outputs (passwords redacted)
- [x] Validate access (`su`/`ssh` or equivalent) — show `whoami` and `id`
- [x] Show final command to retrieve flag (e.g., `cat /home/<user>/flag.txt`)
- [ ] Find hidden flag (optional)