### PR TITLE
docs: add write-up for mission 0x09 (victoria > isla)

### DIFF
--- a/venus/0x09.md
+++ b/venus/0x09.md
@@ -1,0 +1,64 @@
+# 0x09
+
+This write-up walks through how mission 0x09 was completed, moving from user `victoria` to `isla` and secured `isla`'s flag.
+
+---
+
+As usual, read the objective:
+
+```bash
+victoria@venus:~$ cat mission.txt 
+################
+# MISSION 0x09 #
+################
+
+## EN ##        
+The user isla has left her password in a zip file.      
+
+## ES ##
+La usuaria isla ha dejado su password en un fichero zip.
+```
+
+In the home directory there is a zip file like what the hint said about. However, because we don't have permission to create something in the home directory, we can't extract the file.
+
+Then, we create a temporary directory under `/tmp` and copy that file into it:
+
+```bash
+victoria@venus:~$ mkdir /tmp/18512
+victoria@venus:~$ cp ./passw0rd.zip /tmp/18512
+```
+
+Move to `/tmp/18512` and extract the zip file here:
+
+```bash 
+victoria@venus:~$ cd /tmp/18512
+victoria@venus:/tmp/18512$ unzip passw0rd.zip 
+Archive:  passw0rd.zip
+ extracting: pwned/victoria/passw0rd.txt  
+ ```
+
+Print the password:
+
+```bash
+victoria@venus:/tmp/18512$ cat /pwned/victoria/passw0rd.txt 
+[REDACTED]
+```
+
+Verify it by switching to user `isla`:
+
+```bash
+victoria@venus:/tmp/18512/pwned/victoria$ su - isla
+Password: 
+isla@venus:~$ whoami ; id
+isla
+uid=1010(isla) gid=1010(isla) groups=1010(isla)
+```
+
+Read the flag:
+
+```bash
+isla@venus:~$ cat flagz.txt 
+[REDACTED]
+```
+
+Objective Secured.


### PR DESCRIPTION
### Description:

Resolves #11 

This PR adds the complete write-up for **Mission 0x09** on the `venus` machine, documenting the privilege escalation path from user `victoria` to `isla`.

#### Solution Summary
Following the hint in `mission.txt`, the password for `isla` was located within a zip file.

1.  A zip file named `passw0rd.zip` was found in `victoria`'s home directory.
2.  Due to permissions, the file could not be extracted in place. A temporary directory was created at `/tmp/18512`.
3.  The `passw0rd.zip` file was copied to the temporary directory.
4.  The `unzip` command was used, which extracted the password file to `pwned/victoria/passw0rd.txt`.
5.  Reading this file revealed the password for `isla`.
6.  Access was validated using `su - isla` and confirmed with `whoami ; id`.
7.  The user flag was retrieved using `cat flagz.txt`.

#### Issue Checklist
- [x] Include mission text (EN/ES if present)
- [x] Describe estimated approach based on hint
- [x] Command steps & outputs (passwords redacted)
- [x] Validate access (`su`/`ssh` or equivalent) — show `whoami` and `id`
- [x] Show final command to retrieve flag (e.g., `cat /home/<user>/flag.txt`)
- [ ] Find hidden flag (optional)