### PR TITLE
docs: add write-up for mission 0x10 (isla > violet)

### DIFF
--- a/venus/0x10.md
+++ b/venus/0x10.md
@@ -1,0 +1,67 @@
+# 0x10
+
+This write-up walks through how mission 0x10 was completed, moving from user `isla` to `violet` and secured `violet`'s flag.
+
+---
+
+As always, read the mission first:
+
+```bash
+isla@venus:~$ cat mission.txt 
+################
+# MISSION 0x10 #
+################
+
+## EN ##
+The password of the user violet is in the line that begins with a9HFX (these 5 characters are not part of her password.).
+
+## ES ##
+El password de la usuaria violet esta en la linea que empieza por a9HFX (sin ser estos 5 caracteres parte de su password.).
+```
+
+In the home directory, there is a file named `passy`, when we look into it:
+
+```bash
+isla@venus:~$ cat passy 
+gRfsUwzARHdRSUOrXbvc
+vTLXwbzOnYzjPRRzshdN
+lZUtoGkBCVcfSzRpbAFA
+WnmzolwEtyoWYPprSvHf
+kOAxfgMrNHMTdrlyrMVu
+xirtXpDZsYBBVzsYUalW
+-------[SNIP]-------
+ERmFbAXzjEUhvqNWckxv
+JHbLHzEGnwOEffvUazwF
+ndocUrxRYCPIEftpaxHD
+nRcIAFUAMkaAjYHBIRNv
+NyJUCiEupUYOOMyIprOf
+```
+
+There are so many lines inside, it's not efficient to look at it line after line. 
+
+The hint mentioned the password is in the line that begins with `a9HFX` but these 5 characters are not part of the password.
+
+Use `grep` command to get the line:
+
+```bash
+isla@venus:~$ grep "^a9HFX" passy 
+a9HFX[REDACTED]
+```
+Verify it by switch to user `violet`:
+
+```bash
+isla@venus:~$ su - violet
+Password: 
+violet@venus:~$ whoami ; id
+violet
+uid=1011(violet) gid=1011(violet) groups=1011(violet)
+```
+
+Succesfully logged in. Now, print out the flag:
+
+```bash
+violet@venus:~$ cat flagz.txt 
+[REDACTED]
+```
+
+Objective secured.


### PR DESCRIPTION
### Description

Resolves #12 

This PR adds the complete write-up for **Mission 0x10** on the `venus` machine. This solution details the privilege escalation path from user `isla` to `violet`.

#### Solution Summary
As per the hint in `mission.txt`, the password for `violet` is located in a line that begins with the characters `a9HFX`, and these characters are not part of the actual password.

1.  A file named `passy` was identified in the home directory.
2.  The `grep "^a9HFX" passy` command was used to instantly locate the line containing the password.
3.  The password was identified as the content of that line *after* the initial `a9HFX` prefix.
4.  Access was successfully validated by switching users with `su - violet` and confirming identity with `whoami ; id`.
5.  The user flag was retrieved by running `cat flagz.txt`.

#### Issue Checklist
- [x] Include mission text (EN/ES if present)
- [x] Describe estimated approach based on hint
- [x] Command steps & outputs (passwords redacted)
- [x] Validate access (`su`/`ssh` or equivalent) — show `whoami` and `id`
- [x] Show final command to retrieve flag (e.g., `cat /home/<user>/flag.txt`)
- [ ] Find hidden flag (optional)